### PR TITLE
Correct ESLint flat config, deprecated locale usage, and import errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,8 @@
-import { fixupConfigRules, fixupPluginRules } from "@eslint/compat"
+import {
+  fixupConfigRules,
+  fixupPluginRules,
+  includeIgnoreFile,
+} from "@eslint/compat"
 import { FlatCompat } from "@eslint/eslintrc"
 import js from "@eslint/js"
 import typescriptEslint from "@typescript-eslint/eslint-plugin"
@@ -15,11 +19,12 @@ import simpleImportSort from "eslint-plugin-simple-import-sort"
 import tailwindcss from "eslint-plugin-tailwindcss"
 import unusedImport from "eslint-plugin-unused-imports"
 import globals from "globals"
-import { dirname } from "path"
+import { dirname, resolve } from "path"
 import { fileURLToPath } from "url"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
+const gitIgnoreFile = resolve(__dirname, ".gitignore")
 
 const compat = new FlatCompat({
   baseDirectory: __dirname,
@@ -35,18 +40,12 @@ const twOptions = {
 const eslintConfig = [
   {
     files: ["**/*.{js,jsx,ts,tsx,mjs}"],
-    ignores: [
-      "**/node_modules/**",
-      "**/dist/**",
-      "**/build/**",
-      "**/.next/**",
-      "**/public/**",
-    ],
   },
+  includeIgnoreFile(gitIgnoreFile),
   ...fixupConfigRules(
-    ...compat.extends(
-      "next",
+    compat.extends(
       "eslint:recommended",
+      "next",
       "next/core-web-vitals",
       "next/typescript",
       "plugin:react-hooks/recommended",
@@ -315,6 +314,12 @@ const eslintConfig = [
       ],
       "simple-import-sort/exports": "error",
       "import/first": "error",
+      "import/no-unresolved": [
+        "error",
+        {
+          ignore: ["^geist/font"],
+        },
+      ],
       "import/newline-after-import": [
         "error",
         {

--- a/src/shared/i18n/request.ts
+++ b/src/shared/i18n/request.ts
@@ -1,24 +1,13 @@
 import { getRequestConfig } from "next-intl/server"
 
 import { DEFAULT_LOCALE, LOCALES } from "./config/constants"
-import { getLocale, setLocale } from "./lib/cookies"
 import { type Locales } from "./model/types"
 
-export default getRequestConfig(async ({ locale: requestLocale }) => {
-  let locale: Locales
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale: Locales | string
+  locale = (await requestLocale) ?? DEFAULT_LOCALE
 
-  try {
-    locale = await getLocale()
-    if (requestLocale && requestLocale !== locale) {
-      await setLocale(requestLocale as Locales)
-      locale = requestLocale as Locales
-    }
-  } catch (error) {
-    console.error("Error getting locale:", error)
-    locale = (requestLocale as Locales) || DEFAULT_LOCALE
-  }
-
-  if (!LOCALES.includes(locale)) {
+  if (!LOCALES.includes(locale as Locales)) {
     locale = DEFAULT_LOCALE
   }
 


### PR DESCRIPTION
# This commit addresses Issue #1

- Separated `files` and `ignores` in ESLint flat config to prevent parser errors.
- Implemented `.gitignore` inclusion for ignored files using `includeIgnoreFile` for cleaner config.
- Updated `next-intl` to use `requestLocale` instead of deprecated `locale` param for route-based localization.
- Fixed ESLint plugin/extensions not being applied by correcting `compat.extends` usage.
- Resolved `import/no-unresolved` errors by adding an exception for `geist/font/*` imports.